### PR TITLE
Fix type-mismatch parsing issue

### DIFF
--- a/domain.go
+++ b/domain.go
@@ -50,7 +50,7 @@ type DNSDetails struct {
 }
 
 type Whoisguard struct {
-	Enabled     bool   `xml:"Enabled,attr"`
+	Enabled     string `xml:"Enabled,attr"`
 	ID          int64  `xml:"ID"`
 	ExpiredDate string `xml:"ExpiredDate"`
 }

--- a/domain_test.go
+++ b/domain_test.go
@@ -151,7 +151,7 @@ func TestDomainGetInfo(t *testing.T) {
 			},
 		},
 		Whoisguard: Whoisguard{
-			Enabled:     true,
+			Enabled:     "True",
 			ID:          53536,
 			ExpiredDate: "11/04/2015",
 		},


### PR DESCRIPTION
- The 'Enabled' attribute cannot be parsed as a bool, as it can hold a string value of "NotAllotted".

- Hence, this has been now marked as type string and the associated test has been updated to reflect this.